### PR TITLE
Remove copying of unnecessary files to VSAC dir

### DIFF
--- a/files/scripts/do-magic.sh
+++ b/files/scripts/do-magic.sh
@@ -4,11 +4,7 @@ mkdir -p /etc/ccda/files/validator_configuration/vocabulary/code_repository
 mkdir -p /etc/ccda/files/validator_configuration/scenarios_directory
 
 echo "Copying validator-api xlsx's..."
-cp /etc/submodules/code-validator-api/codevalidator-api/docs/*.xlsx /etc/ccda/files/validator_configuration/vocabulary/valueset_repository/VSAC/
 cp /etc/submodules/code-validator-api/codevalidator-api/docs/ValueSetsHandCreatedbySITE/*.xlsx /etc/ccda/files/validator_configuration/vocabulary/valueset_repository/VSAC/
-
-### Removing this file fixes an error 02:11:59,585 ERROR [VocabularyLoadRunner:107] Failed to load configured vocabulary directory.
-rm /etc/ccda/files/validator_configuration/vocabulary/valueset_repository/VSAC/ValueSet_format_Template.xlsx
 
 echo "Downloading reference-cdda-validator war file..."
 wget https://github.com/siteadmin/reference-ccda-validator/releases/download/1.0.37/referenceccdaservice.war -O /var/lib/tomcat/webapps/referenceccdaservice.war


### PR DESCRIPTION
I haven't tested this change but just checking out the work you guys have done and noticed this bash script. The files in https://github.com/siteadmin/code-validator-api/tree/master/codevalidator-api/docs with the exception of the subfolder ValueSetsHandCreatedbySITE are just informational for the user/not meant to be machine-readable/added to the VSAC folder. Only value sets should be in the VSAC folder as the validator will try to load them as such. This is why the one file previously had to be removed/caused in error if it was not. You could copy them to some other directory if that is useful to have local for a user or if you happen to be referencing these files elsewhere. By the way this is a really cool project. I will try it out soon and would like to further discuss it.